### PR TITLE
Add PHAR support

### DIFF
--- a/sbin/phar.php
+++ b/sbin/phar.php
@@ -1,0 +1,33 @@
+#!/usr/bin/env php -d phar.readonly=0
+<?php
+
+if (!isset($_SERVER['argv'][1])) {
+    throw new RuntimeException(
+        'The PHAR path is missing. Please, try with: '.
+        '`' . implode(' ', $_SERVER['argv']) . ' /tmp/kitab.phar`.'
+    );
+}
+
+$fileName = $_SERVER['argv'][1];
+
+if (true === file_exists($fileName)) {
+    throw new RuntimeException(
+        'The PHAR ' . $fileName . ' already exist. Do not want to overwrite it.'
+    );
+}
+
+$root = dirname(__DIR__) . DIRECTORY_SEPARATOR;
+
+$_flags = FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::CURRENT_AS_FILEINFO | FilesystemIterator::SKIP_DOTS;
+
+$iterator = new AppendIterator();
+$iterator->append(new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root . 'bin', $_flags)));
+$iterator->append(new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root . 'src', $_flags)));
+$iterator->append(new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root . 'vendor', $_flags)));
+$iterator->append(new GlobIterator($root . '*.*'));
+
+$phar = new Phar($fileName, 0, 'Kitab.phar');
+$phar->buildFromIterator($iterator, $root);
+$phar->setSignatureAlgorithm(Phar::SHA512);
+
+$phar->setStub(file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'phar.stub.php'));

--- a/sbin/phar.stub.php
+++ b/sbin/phar.stub.php
@@ -1,0 +1,27 @@
+<?php
+
+define('KITAB_PHAR_NAME', 'Kitab.phar');
+define('KITAB_PHAR_PATH', realpath($_SERVER['argv'][0]));
+
+Phar::mapPhar(KITAB_PHAR_NAME);
+
+require_once 'phar://' . KITAB_PHAR_NAME . '/src/Bootstrap.php';
+
+if (isset($_SERVER['argv'][1]) && 'atoum' === $_SERVER['argv'][1]) {
+    // Clean `$_SERVER` for atoum.
+    unset($_SERVER['argv'][1]);
+
+    // Manually add the configuration file.
+    mageekguy\atoum\scripts\runner::addConfigurationCallable(
+        function ($script, $runner) {
+            require_once 'phar://' . KITAB_PHAR_NAME . '/src/DocTest/.atoum.php';
+        }
+    );
+
+    // Run atoum.
+    require_once 'phar://' . KITAB_PHAR_NAME . '/vendor/atoum/atoum/scripts/runner.php';
+} else {
+    require_once 'phar://' . KITAB_PHAR_NAME . '/src/Bin/Kitab.php';
+}
+
+__HALT_COMPILER();

--- a/src/Bin/Kitab.php
+++ b/src/Bin/Kitab.php
@@ -1,5 +1,6 @@
-#!/usr/bin/env php
 <?php
+
+declare(strict_types=1);
 
 /**
  * Hoa
@@ -37,6 +38,6 @@
 
 require_once
     dirname(__DIR__) . DIRECTORY_SEPARATOR .
-    'src' . DIRECTORY_SEPARATOR .
-    'Bin' . DIRECTORY_SEPARATOR .
-    'Kitab.php';
+    'Bootstrap.php';
+
+Kitab\Bin\Bin::main();

--- a/src/Bin/Test.php
+++ b/src/Bin/Test.php
@@ -134,6 +134,8 @@ class Test extends Console\Dispatcher\Kit
         if (is_dir($outputDirectory)) {
             $since = time() - filemtime($outputDirectory);
             $finder->modified('since ' . $since . ' seconds');
+        } else {
+            File\Directory::create($outputDirectory);
         }
 
         $target = new DocTest();
@@ -144,7 +146,10 @@ class Test extends Console\Dispatcher\Kit
         if (defined('KITAB_PHAR_NAME')) {
             $command = PHP_BINARY . ' ' . KITAB_PHAR_PATH . ' atoum';
 
-            $temporaryAutoloader = new File\Write(Temporary::create());
+            $temporaryAutoloaderPath = $outputDirectory . '.kitab.phar.autoloader.php';
+            touch($temporaryAutoloaderPath);
+
+            $temporaryAutoloader = new File\Write($temporaryAutoloaderPath, File::MODE_TRUNCATE_WRITE);
             $temporaryAutoloader->writeAll(
                 '<?php' . "\n\n" .
                 'Phar::loadPhar(\'' . KITAB_PHAR_PATH . '\', \'' . KITAB_PHAR_NAME . '\');' . "\n\n" .
@@ -172,7 +177,10 @@ class Test extends Console\Dispatcher\Kit
                 ' --configurations ' .
                     dirname(__DIR__) . DS . 'DocTest' . DS . '.atoum.php';
 
-            $temporaryAutoloader = new File\Write(Temporary::create());
+            $temporaryAutoloaderPath = $outputDirectory . '.kitab.autoloader.php';
+            touch($temporaryAutoloaderPath);
+
+            $temporaryAutoloader = new File\Write($temporaryAutoloaderPath, File\File::MODE_TRUNCATE_WRITE);
             $temporaryAutoloader->writeAll(
                 '<?php' . "\n\n" .
                 'require_once \'' . str_replace("'", "\\'", realpath(dirname(__DIR__, 2) . DS . 'vendor' . DS . 'autoload.php')) . '\';' . "\n" .

--- a/src/Bin/Test.php
+++ b/src/Bin/Test.php
@@ -88,6 +88,10 @@ class Test extends Console\Dispatcher\Kit
                 case 'l':
                     $autoloader = $v;
 
+                    if (false === file_exists($autoloader)) {
+                        throw new \RuntimeException('Autoloader file `' . $autoloader . '` does not exist.');
+                    }
+
                     break;
 
                 case 'v':
@@ -154,7 +158,7 @@ class Test extends Console\Dispatcher\Kit
                 '<?php' . "\n\n" .
                 'Phar::loadPhar(\'' . KITAB_PHAR_PATH . '\', \'' . KITAB_PHAR_NAME . '\');' . "\n\n" .
                 'require_once \'phar://'. KITAB_PHAR_NAME .'/vendor/autoload.php\';' . "\n" .
-                'require_once \'' . str_replace("'", "\\'", realpath($autoloader)) . '\';'
+                (!empty($autoloader) ? 'require_once \'' . str_replace("'", "\\'", realpath($autoloader)) . '\';' : '')
             );
 
             $autoloader = $temporaryAutoloader->getStreamName();
@@ -184,7 +188,7 @@ class Test extends Console\Dispatcher\Kit
             $temporaryAutoloader->writeAll(
                 '<?php' . "\n\n" .
                 'require_once \'' . str_replace("'", "\\'", realpath(dirname(__DIR__, 2) . DS . 'vendor' . DS . 'autoload.php')) . '\';' . "\n" .
-                'require_once \'' . str_replace("'", "\\'", realpath($autoloader)) . '\';'
+                (!empty($autoloader) ? 'require_once \'' . str_replace("'", "\\'", realpath($autoloader)) . '\';' : '')
             );
 
             $autoloader = $temporaryAutoloader->getStreamName();

--- a/src/README.md
+++ b/src/README.md
@@ -21,7 +21,7 @@ great look for your documentation. This is possible to customize the
 logo, the project name, etc.
 
 A static search engine is compiled specifically for your
-documentation. It contains all the modern feature we can expect from a
+documentation. It contains all the modern features we can expect from a
 search engine, like tokenizing, stemming, stop word filtering, term
 frequency-inverse document frequency (TF-ID), inverted index etc. The
 search engine database is pre-computed and optimized to load as fast


### PR DESCRIPTION
And it was totally crazy.

Generating the PHAR is easy. The stub is easy. However, `atoum` is
inside the PHAR. We run `atoum` from a shell (now directly from PHP, but
still from a shell). A shell cannot load a file inside a PHAR, that's
obvious. The idea is to expose `atoum` through a “private” API:
`kitab.phar atoum`.

So now, Kitab in a PHAR can execute atoum. However, we have a big issue
with autoloaders. Kitab needs its own autoloader that is inside the
PHAR. And the project under test has its own autoloader outside the
PHAR. More importantly, atoum can have only one autoloader at a
time. The trick is to generate a temporary file —a temporary autoloader—
that includes the autoloaders from Kitab and from the project under
test. To use the autoloader of Kitab, we have to map/load the PHAR. The
temporary autoloader is then used as the autoloader file for atoum.

And it works. Next commits will optimize this process, but it works.